### PR TITLE
add CI/CD configuration

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: Dockerfile
+run:
+  web: dotnet YCodeLab.dll


### PR DESCRIPTION
For Heroku deployment, it now requires CI/CD configuration.

This merge adds heroku.yml to run docker build by Heroku deployment process.